### PR TITLE
Documentation improvements.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,7 +72,7 @@ source_suffix = '.rst'
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = None
+# pygments_style = None
 
 default_role = 'any'
 
@@ -116,8 +116,10 @@ extlinks = {'issue': ('https://github.com/kassonlab/brer-md/issues/%s',
             'Issue': ('https://github.com/kassonlab/brer-md/issues/%s',
                       'Issue #%s')}
 
-# -- Extension configuration -------------------------------------------------
+# -- Autodoc extension configuration -------------------------------------------------
+# Ref https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration
 autoclass_content = 'both'
+autodoc_typehints = 'description'
 
 # -- Options for intersphinx extension ---------------------------------------
 
@@ -133,3 +135,20 @@ intersphinx_mapping = {
 todo_include_todos = False
 # Override from the command line with `-D todo_include_todos=1`.
 # E.g. `cd docs; sphinx-build -b html -D todo_include_todos=1 source _build/html`
+
+# Napoleon settings
+# Ref https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#configuration
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+# napoleon_include_init_with_doc = False
+# napoleon_include_private_with_doc = False
+# napoleon_include_special_with_doc = True
+# napoleon_use_admonition_for_examples = False
+# napoleon_use_admonition_for_notes = False
+# napoleon_use_admonition_for_references = False
+# napoleon_use_ivar = False
+# napoleon_use_param = True
+# napoleon_use_rtype = True
+# napoleon_preprocess_types = False
+# napoleon_type_aliases = None
+# napoleon_attr_annotations = True

--- a/docs/source/developer_api.rst
+++ b/docs/source/developer_api.rst
@@ -8,25 +8,6 @@ directory_helper
 .. autoclass:: brer.directory_helper.DirectoryHelper
     :members:
 
-metadata
-========
-.. automodule:: brer.metadata
-
-.. autoclass:: brer.metadata.MetaData
-    :members:
-.. autoclass:: brer.metadata.MultiMetaData
-    :members:
-
-pair_data
-=========
-.. automodule:: brer.pair_data
-
-.. autoclass:: brer.pair_data.PairData
-    :members:
-
-.. autoclass:: brer.pair_data.MultiPair
-    :members:
-
 plugin_configs
 ==============
 .. automodule:: brer.plugin_configs

--- a/docs/source/user_api.rst
+++ b/docs/source/user_api.rst
@@ -10,7 +10,28 @@ BRER runner
 
 BRER parameters
 ===============
+
+*pair_data* module
+------------------------
+
+.. automodule:: brer.pair_data
+
+.. autoclass:: brer.pair_data.PairData
+    :members:
+
+.. autoclass:: brer.pair_data.MultiPair
+    :members:
+
+*run_data* module
+-------------------
+
 .. automodule:: brer.run_data
 
 .. autoclass:: brer.run_data.RunData
+    :members:
+
+.. autoclass:: brer.run_data.GeneralParams
+    :members:
+
+.. autoclass:: brer.run_data.PairParams
     :members:

--- a/src/brer/pair_data.py
+++ b/src/brer/pair_data.py
@@ -49,9 +49,9 @@ class PairData:
     name: str = dataclasses.field(**field_kwargs)
     """Identifier for the pair of sites on the molecule.
     
-    Conventionally, this is a string constructed from the two integer indices
-    of relevant atoms in the molecular model that best correspond to the
-    labeled sites of interest.
+    This string is chosen by the researcher. For example, the name may
+    include identifiers for the two residues in a scheme that can be easily
+    cross-referenced with experimental data.
     """
 
     bins: List[float] = dataclasses.field(**field_kwargs)

--- a/src/brer/pair_data.py
+++ b/src/brer/pair_data.py
@@ -1,5 +1,11 @@
-"""Classes to handle 1) pair metadata 2) resampling from DEER distributions at
-each new BRER iteration."""
+"""BRER data for site pairs.
+
+Coordinate the experimental reference data and molecular model data for the
+labeled / restrained pairs.
+
+Support the statistical (re)sampling of target pair distances when beginning a
+BRER iteration.
+"""
 import dataclasses
 import json
 import sys
@@ -32,15 +38,51 @@ class PairData:
 
     Essential pair data to support BRER MD plugin code. All data must be
     provided when the object is initialized. (Fields are read-only.)
+
+    Fields here correspond to the fields for each named pair
+    (JSON *objects*) in a :file:`pair_data.json` file (the *pairs_json* argument
+    of :py:func:`~brer.run_config.RunConfig()`).
     """
     # Historically, *name* has sometimes been provided as a positional argument,
     # but this led to ambiguity in the source of the final value of the field.
     # We define the *name* field first in case we overlook some legacy usage.
     name: str = dataclasses.field(**field_kwargs)
+    """Identifier for the pair of sites on the molecule.
+    
+    Conventionally, this is a string constructed from the two integer indices
+    of relevant atoms in the molecular model that best correspond to the
+    labeled sites of interest.
+    """
 
     bins: List[float] = dataclasses.field(**field_kwargs)
+    """Histogram edges for the distance distribution data.
+    
+    (Simulation length units.)
+    """
+
     distribution: List[float] = dataclasses.field(**field_kwargs)
+    """Site distance distribution.
+    
+    Histogram values (weights or relative probabilities) for distances between
+    the sites. (Generally derived from experimental data.)
+    """
+
     sites: List[int] = dataclasses.field(**field_kwargs)
+    """Indices defining the distance vector.
+    
+    A list of indices for sites in the molecular model. The first and last
+    list elements are the sites associated with the distance data. Additional
+    indices can be inserted in the list to define a chain of distance vectors
+    that will be added without applying periodic boundary conditions.
+    
+    If, at any point in the simulation, the two molecular sites in the pair
+    might be farther apart than half of the shortest simulation box dimension,
+    the distance might accidentally get calculated between sites on different
+    molecule "images" (periodic boundary conditions). To make sure that site-site
+    distances are calculated on the same molecule, provide a sequence of sites
+    on the molecule (that are never more than half a box-length apart) so that
+    the correct vector between sites is unambiguous.
+    """
 
 
 class MultiPair(MultiMetaData):

--- a/src/brer/plugin_configs.py
+++ b/src/brer/plugin_configs.py
@@ -47,8 +47,11 @@ def _get_workelement() -> typing.Type:
 
 @dataclasses.dataclass
 class PluginConfig(ABC):
-    """Abstract class used to build training, convergence, and production
-    plugins."""
+    """Abstract class for the BRER potential configurations.
+
+    Provide base class functionality and required interface to build ``training``,
+    ``convergence``, and ``production`` phase pluggable MD potentials.
+    """
     name: str = dataclasses.field(init=False, **field_kwargs)
     sites: List[int] = dataclasses.field(**field_kwargs)
     logging_filename: str = dataclasses.field(**field_kwargs)
@@ -72,6 +75,8 @@ class PluginConfig(ABC):
 
         Extra fields in *obj* are ignored.
         """
+        if cls is PluginConfig:
+            raise NotImplementedError
         return cls(**{key: getattr(obj, key) for key in [field.name for field in dataclasses.fields(cls) if
                                                          field.init] if hasattr(obj, key)})
 

--- a/src/brer/run_config.py
+++ b/src/brer/run_config.py
@@ -50,7 +50,48 @@ except (ImportError, ModuleNotFoundError):
 
 
 class RunConfig:
-    """Run configuration for single BRER ensemble member."""
+    """Run configuration for single BRER ensemble member.
+
+    The run configuration specifies the files and directory structure
+    used for the run. It determines whether the run is in the training,
+    convergence, or production phase, then performs the run.
+
+    Note that all instances of RunConfig need the same sized array of TPR input
+    files across all ranks in an MPI ensemble because they must all be capable of
+    constructing a compatible copy of the ensemble simulation work description.
+
+    Source data for the pair restraints is provided through a JSON file
+    (*pairs_json*). The JSON file contains one *JSON object* for each
+    :py:class:`~brer.pair_data.PairData` to be read.
+
+    For each object, the object key is assumed to be the
+    :py:data:`~brer.pair_data.PairData.name` of a pair.
+    The JSON object contents are used to initialize a
+    :py:class:`~brer.pair_data.PairData` for each named pair.
+
+    The data file is usually constructed manually by the researcher after
+    inspection of a molecular model and available experimental data. An example
+    of what such a file should look like is provided in the :file:`brer/data`
+    directory of the installed package or
+    `in the source <https://github.com/kassonlab/brer-md/tree/main/src/brer/data>`__
+    repository. Note that JSON is not a Python-specific file format, but
+    :py:mod:`json` may be helpful.
+
+    Parameters
+    ----------
+    tpr : str
+        path (or paths) to tpr input. Must be compatible with the GROMACS version
+        providing gmxapi.
+    ensemble_dir : str
+        path to top directory which contains the full ensemble.
+    ensemble_num : int, optional
+        the ensemble member to run, by default 1
+    pairs_json : str, default="pair_data.json"
+        path to file containing *ALL* the pair metadata.
+        (A collection of serialized :py:class:`brer.pair_data.PairData` objects.)
+
+
+    """
 
     @property
     def tpr(self):
@@ -61,29 +102,6 @@ class RunConfig:
                  ensemble_dir,
                  ensemble_num: int = None,
                  pairs_json='pair_data.json'):
-        """The run configuration specifies the files and directory structure
-        used for the run. It determines whether the run is in the training,
-        convergence, or production phase, then performs the run.
-
-        Parameters
-        ----------
-        tpr : str
-            path (or paths) to tpr input. Must be compatible with the GROMACS version
-            providing gmxapi.
-        ensemble_dir : str
-            path to top directory which contains the full ensemble.
-        ensemble_num : int, optional
-            the ensemble member to run, by default 1
-        pairs_json : str, optional
-            path to file containing *ALL* the pair metadata.
-            An example of what such a file should look like is provided in the data
-            directory,
-            by default 'pair_data.json'
-
-        Note that all instances of RunConfig need the same sized array of TPR input
-        files across all ranks in an MPI ensemble because they must all be capable of
-        constructing a compatible copy of the ensemble simulation work description.
-        """
         if isinstance(tpr, (str, pathlib.Path, os.PathLike)):
             self._tprs = tuple([str(tpr)])
             self._ensemble_size = 1

--- a/src/brer/run_data.py
+++ b/src/brer/run_data.py
@@ -1,4 +1,19 @@
-"""Class that handles the simulation data for BRER simulations.
+"""Handle simulation data for BRER simulations.
+
+`RunData` manages general parameters (`GeneralParams`) and pair-specific
+parameters (`PairParams`) for a single simulator for a specific phase of the
+BRER method.
+
+Parameters are initially provided through the
+:py:class:`~brer.run_config.RunConfig`, and are then stored to (and restored
+from) an internally managed :file:`state.json` file.
+
+Not all parameters are applicable to all BRER phases.
+
+See Also
+--------
+:py:mod:`brer.plugin_configs`
+
 """
 import dataclasses
 import json
@@ -31,14 +46,16 @@ else:
 
 @dataclass(**dataclass_kwargs)
 class GeneralParams:
-    """Stores the parameters that are shared by all restraints in a single
-    simulation.
+    """Store the parameters shared by all restraints in a single simulation.
 
-    These include some of the "Voth" parameters: tau, A, tolerance
+    These include some of the "Voth" parameters: *tau*, *A*, *tolerance*
 
     .. versionadded:: 2.0
         The *end_time* parameter.
 
+    Update general parameters before a call to
+    :py:meth:`brer.run_config.RunConfig.run()` by calling
+    :py:meth:`brer.run_data.RunData.set()` without a *name* argument.
     """
     name: str = field(init=False, default='general')
     A: float = 50.
@@ -56,7 +73,19 @@ class GeneralParams:
 
 @dataclass(**dataclass_kwargs)
 class PairParams:
-    """Stores the parameters that are unique to a specific restraint."""
+    """Stores the parameters that are unique to a specific restraint.
+
+    *PairParams* is a mutable structure for run time data. Fields such as
+    *alpha* and *target* may be updated automatically while running *brer*.
+
+    *PairParams* should not be confused with
+    :py:class:`~brer.pair_data.PairData` (an input data structure).
+
+    Update pair-specific parameters before a call to
+    :py:meth:`brer.run_config.RunConfig.run()` by calling
+    :py:meth:`brer.run_data.RunData.set()`, providing the pair name with the
+    *name* argument.
+    """
     name: str
     sites: List[int]
     logging_filename: str = None
@@ -75,8 +104,7 @@ class PairParams:
 
 
 class RunData:
-    """Stores (and manipulates, to a lesser extent) all the metadata for a BRER
-    run."""
+    """Store (and manipulate, to a lesser extent) all the metadata for a BRER run."""
 
     def __init__(self):
         """The full set of metadata for a single BRER run include both the


### PR DESCRIPTION
Document `PairData` and *pairs_json* argument.
Fixes #9

Expand, clarify, and reorganize some documentation for data structures.

Disambiguate that we are using Numpy docstring style, and fix some formatting. See #8