### PR TITLE
Docs build updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,7 +245,7 @@ jobs:
       if: success()
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ github.job }}-${{ env.GROMACS }}
+        name: brer-docs-${{ github.job }}-${{ env.GROMACS }}
         path: |
           docs/_build/html/
     - name: "Upload artifacts for failure"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -225,17 +225,30 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
+    - name: Docs preview
+      run: |
+        . $HOME/venv/bin/activate
+        pip install -r docs/requirements.txt
+        TODO_OPTIONS="-D todo_include_todos=1"
+        SPHINX_OPTIONS="${TODO_OPTIONS} -D html_theme_options.source_branch=${GITHUB_HEAD_REF:-main}"
+        (cd docs && sphinx-build -b html ${SPHINX_OPTIONS} source _build/html)
     - name: Docs
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       run: |
         . $HOME/venv/bin/activate
-        pip install sphinx sphinx-rtd-theme
         pip install -r docs/requirements.txt
         export GITHUB_ACTOR=$GITHUB_ACTOR
         export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         export GITHUB_REPOSITORY=$GITHUB_REPOSITORY
         bash -x ./ci_scripts/docs/buildsite.sh
-    - name: "Upload artifacts"
+    - name: "Upload documentation artifacts"
+      if: success()
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}-${{ env.GROMACS }}
+        path: |
+          docs/_build/html/
+    - name: "Upload artifacts for failure"
       if: failure()
       uses: actions/upload-artifact@v3
       with:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
+furo
 sphinx>=4
-sphinx_rtd_theme
+sphinx-copybutton
+sphinx_inline_tabs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,14 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../'))
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('../'))
 
+# The BRER project documentation uses autodoc to extract docstrings from the
+# compiled brer.md extension. For this to work, the package should be installed
+# in the current Python environment. An "editable" install (`pip install -e ...`)
+# should suffice.
 
 # -- Project information -----------------------------------------------------
 
@@ -51,7 +55,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -81,13 +85,18 @@ default_role = 'any'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#
-# html_theme_options = {}
+# Ref: https://pradyunsg.me/furo/customisation/
+html_theme_options = {
+    # Add an "edit" button to the rendered web pages.
+    "source_repository": "https://github.com/kassonlab/brer-md/",
+    "source_branch": "main",
+    "source_directory": "docs/source/",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -108,7 +117,7 @@ html_theme = 'sphinx_rtd_theme'
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'runBRERdoc'
+htmlhelp_basename = 'BRERdoc'
 
 # -- options for extlinks extension -
 extlinks = {'issue': ('https://github.com/kassonlab/brer-md/issues/%s',


### PR DESCRIPTION
Apply the furo theme.

Allow a preview of the built docs in the Actions artifacts.

This will make it easier to get help finishing #8 and to make future docs changes.

Note that the zip archive of artifacts from the GitHub Actions will now include a preview of the built docs for easy download and local viewing. The docs are built with a correctly-configured link to the branch from which the PR originates, so the "Edit" button in the docs allows easy updates to the pull request through the web browser.