### PR TITLE
Add a compatibility utility module.

### DIFF
--- a/src/brer/_compat.py
+++ b/src/brer/_compat.py
@@ -8,7 +8,7 @@ the package.
 * Dataclasses allow tighter control in Python 3.10
 
 """
-__all__ = ['List', 'MutableMapping', 'dataclass_kw_only', 'dataclass_slots']
+__all__ = ['Iterable', 'List', 'Mapping', 'MutableMapping', 'dataclass_kw_only', 'dataclass_slots']
 
 import collections.abc
 import sys
@@ -26,8 +26,12 @@ else:
     from typing import List
 
 if sys.version_info.major > 3 or sys.version_info.minor >= 9:
+    Iterable = collections.abc.Iterable
+    Mapping = collections.abc.Mapping
     MutableMapping = collections.abc.MutableMapping
 else:
+    Iterable = typing.Iterable
+    Mapping = typing.Mapping
     MutableMapping = typing.MutableMapping
 
 dataclass_kw_only: collections.abc.Mapping

--- a/src/brer/_compat.py
+++ b/src/brer/_compat.py
@@ -1,0 +1,57 @@
+"""Compatibility support for older Python versions.
+
+Provide some imports and alternative definitions depending on Python version
+so that we don't have to have `sys.version_info` conditionals scattered around
+the package.
+
+* Built-in and :py:mod:`collections.abc` containers are not Generic before 3.9.
+* Dataclasses allow tighter control in Python 3.10
+
+"""
+__all__ = ['List', 'MutableMapping', 'dataclass_kw_only', 'dataclass_slots']
+
+import collections.abc
+import sys
+import typing
+
+assert sys.version_info.major >= 3
+_T = typing.TypeVar('_T')
+_KT = typing.TypeVar('_KT')
+_VT_co = typing.TypeVar('_VT_co', covariant=True)
+
+if sys.version_info.major > 3 or sys.version_info.minor >= 9:
+    List: typing.Generic[_T] = list
+    """Generic list type."""
+else:
+    from typing import List
+
+if sys.version_info.major > 3 or sys.version_info.minor >= 9:
+    MutableMapping = collections.abc.MutableMapping
+else:
+    MutableMapping = typing.MutableMapping
+
+dataclass_kw_only: collections.abc.Mapping
+"""Require keyword arguments for dataclass initialization.
+
+We are trying to reduce ambiguity by confirming that the ``name`` field is often
+redundant with a key used to store such an object. To that end, we are trying
+to be more mindful of how these objects are constructed. We will try to prevent
+some previous usage patterns in which data structures were initialized with a
+positional *name* argument, which was then overwritten by a subsequent *set()*.
+Dataclass init arguments can be provided positionally in the order in which
+fields are defined, unless *kw_only=True* (after Py 3.10).
+"""
+
+dataclass_slots: collections.abc.Mapping
+"""Disallow adding attributes to instances.
+
+In Python >= 3.10, the *slots* option to dataclasses will help keep fields
+from accidentally getting added to instances.
+"""
+
+if sys.version_info.major > 3 or sys.version_info.minor >= 10:
+    dataclass_kw_only = {'kw_only': True}
+    dataclass_slots = {'slots': True}
+else:
+    dataclass_kw_only = {}
+    dataclass_slots = {}

--- a/src/brer/pair_data.py
+++ b/src/brer/pair_data.py
@@ -8,28 +8,12 @@ BRER iteration.
 """
 import dataclasses
 import json
-import sys
 
 import numpy as np
 
-from brer.metadata import MultiMetaData
-
-if sys.version_info.major > 3 or sys.version_info.minor >= 9:
-    List = list
-else:
-    from typing import List
-
-# We are trying to reduce ambiguity by confirming that the `name` field is often
-# redundant with a key used to store such an object. To that end, we are trying
-# to be more mindful of how these objects are constructed. We will try to prevent
-# some previous usage patterns in which data structures were initialized with a
-# positional *name* argument, which was then overwritten by a subsequent *set()*.
-# Dataclass init arguments can be provided positionally in the order in which
-# fields are defined, unless *kw_only=True* (after Py 3.10).
-if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
-    field_kwargs = {'kw_only': True}
-else:
-    field_kwargs = {}
+from ._compat import dataclass_kw_only
+from ._compat import List
+from .metadata import MultiMetaData
 
 
 @dataclasses.dataclass(frozen=True)
@@ -46,7 +30,7 @@ class PairData:
     # Historically, *name* has sometimes been provided as a positional argument,
     # but this led to ambiguity in the source of the final value of the field.
     # We define the *name* field first in case we overlook some legacy usage.
-    name: str = dataclasses.field(**field_kwargs)
+    name: str = dataclasses.field(**dataclass_kw_only)
     """Identifier for the pair of sites on the molecule.
     
     This string is chosen by the researcher. For example, the name may
@@ -54,20 +38,20 @@ class PairData:
     cross-referenced with experimental data.
     """
 
-    bins: List[float] = dataclasses.field(**field_kwargs)
+    bins: List[float] = dataclasses.field(**dataclass_kw_only)
     """Histogram edges for the distance distribution data.
     
     (Simulation length units.)
     """
 
-    distribution: List[float] = dataclasses.field(**field_kwargs)
+    distribution: List[float] = dataclasses.field(**dataclass_kw_only)
     """Site distance distribution.
     
     Histogram values (weights or relative probabilities) for distances between
     the sites. (Generally derived from experimental data.)
     """
 
-    sites: List[int] = dataclasses.field(**field_kwargs)
+    sites: List[int] = dataclasses.field(**dataclass_kw_only)
     """Indices defining the distance vector.
     
     A list of indices for sites in the molecular model. The first and last

--- a/src/brer/plugin_configs.py
+++ b/src/brer/plugin_configs.py
@@ -3,30 +3,13 @@
 Each class corresponds to ONE restraint since gmxapi plugins each correspond to one restraint.
 """
 import dataclasses
-import sys
 import typing
 from abc import ABC
 from abc import abstractmethod
 from functools import singledispatchmethod
 
-assert sys.version_info.major >= 3
-
-if sys.version_info.major > 3 or sys.version_info.minor >= 9:
-    List = list
-else:
-    from typing import List
-
-# We are trying to reduce ambiguity by confirming that the `name` field is often
-# redundant with a key used to store such an object. To that end, we are trying
-# to be more mindful of how these objects are constructed. We will try to prevent
-# some previous usage patterns in which data structures were initialized with a
-# positional *name* argument, which was then overwritten by a subsequent *set()*.
-# Dataclass init arguments can be provided positionally in the order in which
-# fields are defined, unless *kw_only=True* (after Py 3.10).
-if sys.version_info.major > 3 or sys.version_info.minor >= 10:
-    field_kwargs = {'kw_only': True}
-else:
-    field_kwargs = {}
+from ._compat import dataclass_kw_only
+from ._compat import List
 
 
 def _get_workelement() -> typing.Type:
@@ -52,9 +35,9 @@ class PluginConfig(ABC):
     Provide base class functionality and required interface to build ``training``,
     ``convergence``, and ``production`` phase pluggable MD potentials.
     """
-    name: str = dataclasses.field(init=False, **field_kwargs)
-    sites: List[int] = dataclasses.field(**field_kwargs)
-    logging_filename: str = dataclasses.field(**field_kwargs)
+    name: str = dataclasses.field(init=False, **dataclass_kw_only)
+    sites: List[int] = dataclasses.field(**dataclass_kw_only)
+    logging_filename: str = dataclasses.field(**dataclass_kw_only)
 
     @abstractmethod
     def build_plugin(self):
@@ -95,13 +78,13 @@ class TrainingPluginConfig(PluginConfig):
 
     See https://pubs.acs.org/doi/10.1021/acs.jpclett.9b01407 for details.
     """
-    name: str = dataclasses.field(init=False, default='training', **field_kwargs)
+    name: str = dataclasses.field(init=False, default='training', **dataclass_kw_only)
 
-    A: float = dataclasses.field(**field_kwargs)
-    num_samples: int = dataclasses.field(**field_kwargs)
-    target: float = dataclasses.field(**field_kwargs)
-    tau: float = dataclasses.field(**field_kwargs)
-    tolerance: float = dataclasses.field(**field_kwargs)
+    A: float = dataclasses.field(**dataclass_kw_only)
+    num_samples: int = dataclasses.field(**dataclass_kw_only)
+    target: float = dataclasses.field(**dataclass_kw_only)
+    tau: float = dataclasses.field(**dataclass_kw_only)
+    tolerance: float = dataclasses.field(**dataclass_kw_only)
 
     def build_plugin(self):
         """Builds training phase plugin for BRER simulations.
@@ -130,12 +113,12 @@ class ConvergencePluginConfig(PluginConfig):
 
     See https://pubs.acs.org/doi/10.1021/acs.jpclett.9b01407 for details.
     """
-    name: str = dataclasses.field(init=False, default='convergence', **field_kwargs)
+    name: str = dataclasses.field(init=False, default='convergence', **dataclass_kw_only)
 
-    alpha: float = dataclasses.field(**field_kwargs)
-    sample_period: float = dataclasses.field(**field_kwargs)
-    target: float = dataclasses.field(**field_kwargs)
-    tolerance: float = dataclasses.field(**field_kwargs)
+    alpha: float = dataclasses.field(**dataclass_kw_only)
+    sample_period: float = dataclasses.field(**dataclass_kw_only)
+    target: float = dataclasses.field(**dataclass_kw_only)
+    tolerance: float = dataclasses.field(**dataclass_kw_only)
 
     def build_plugin(self):
         """Builds convergence phase plugin for BRER simulations.
@@ -170,11 +153,11 @@ class ProductionPluginConfig(PluginConfig):
 
     See https://pubs.acs.org/doi/10.1021/acs.jpclett.9b01407 for details.
     """
-    name: str = dataclasses.field(init=False, default='production', **field_kwargs)
+    name: str = dataclasses.field(init=False, default='production', **dataclass_kw_only)
 
-    alpha: float = dataclasses.field(**field_kwargs)
-    sample_period: float = dataclasses.field(**field_kwargs)
-    target: float = dataclasses.field(**field_kwargs)
+    alpha: float = dataclasses.field(**dataclass_kw_only)
+    sample_period: float = dataclasses.field(**dataclass_kw_only)
+    target: float = dataclasses.field(**dataclass_kw_only)
 
     def build_plugin(self):
         """Builds production phase plugin for BRER simulations.

--- a/src/brer/run_data.py
+++ b/src/brer/run_data.py
@@ -17,34 +17,17 @@ See Also
 """
 import dataclasses
 import json
-import sys
-import typing
 import warnings
 from dataclasses import dataclass
 from dataclasses import field
 
+from ._compat import dataclass_slots
+from ._compat import List
+from ._compat import MutableMapping
 from .pair_data import PairData
 
-if sys.version_info.major > 3 or sys.version_info.minor >= 9:
-    List = list
-else:
-    from typing import List
 
-# In Python >= 3.10, the *slots* option to dataclasses will help keep fields
-# from accidentally getting added to instances.
-if sys.version_info.major == 3 and sys.version_info.minor < 10:
-    __dataclass_has_slots = False
-else:
-    assert sys.version_info.major >= 3
-    __dataclass_has_slots = True
-
-if __dataclass_has_slots:
-    dataclass_kwargs = {'slots': True}
-else:
-    dataclass_kwargs = {}
-
-
-@dataclass(**dataclass_kwargs)
+@dataclass(**dataclass_slots)
 class GeneralParams:
     """Store the parameters shared by all restraints in a single simulation.
 
@@ -71,7 +54,7 @@ class GeneralParams:
     tolerance: float = 0.25
 
 
-@dataclass(**dataclass_kwargs)
+@dataclass(**dataclass_slots)
 class PairParams:
     """Stores the parameters that are unique to a specific restraint.
 
@@ -110,7 +93,7 @@ class RunData:
         """The full set of metadata for a single BRER run include both the
         general parameters and the pair-specific parameters."""
         self.general_params = GeneralParams()
-        self.pair_params: typing.MutableMapping[str, PairParams] = {}
+        self.pair_params: MutableMapping[str, PairParams] = {}
         self.__names = []
 
     def set(self, name=None, **kwargs):


### PR DESCRIPTION
Centralize the handling of workarounds for older Python versions.