### PR TITLE
Normalize and clarify *ensemble_num* default.

### DIFF
--- a/src/brer/run_config.py
+++ b/src/brer/run_config.py
@@ -84,8 +84,8 @@ class RunConfig:
         providing gmxapi.
     ensemble_dir : str
         path to top directory which contains the full ensemble.
-    ensemble_num : int, optional
-        the ensemble member to run, by default 1
+    ensemble_num : int, default=0
+        the ensemble member to run
     pairs_json : str, default="pair_data.json"
         path to file containing *ALL* the pair metadata.
         (A collection of serialized :py:class:`brer.pair_data.PairData` objects.)
@@ -126,13 +126,12 @@ class RunConfig:
             self._communicator = communicator
             self._rank = communicator.Get_rank()
 
-        # WARNING: Previous behavior defaulted to ensemble_num=1
         if ensemble_num is None:
             ensemble_num = self._rank
         else:
             if self._communicator is not None:
                 # Greater future flexibility is described at
-                # https://github.com/kassonlab/run_brer/issues/18
+                # https://github.com/kassonlab/brer-md/issues/7
                 raise TypeError(
                     'RunConfig does not allow *ensemble_num* with mpi4py ensembles.')
 

--- a/src/brer/run_data.py
+++ b/src/brer/run_data.py
@@ -53,6 +53,9 @@ class GeneralParams:
     .. versionadded:: 2.0
         The *end_time* parameter.
 
+    .. versionchanged:: 2.0
+        *ensemble_num* now defaults to 0 for consistency with :py:class:`~brer.run_config.RunConfig`
+
     Update general parameters before a call to
     :py:meth:`brer.run_config.RunConfig.run()` by calling
     :py:meth:`brer.run_data.RunData.set()` without a *name* argument.
@@ -60,7 +63,7 @@ class GeneralParams:
     name: str = field(init=False, default='general')
     A: float = 50.
     end_time: float = 0.
-    ensemble_num: int = 1
+    ensemble_num: int = 0
     iteration: int = 0
     num_samples: int = 50
     phase: str = 'training'


### PR DESCRIPTION
For well over a year, the development code for run_brer has allowed the default *ensemble_num* to be 0, but the docs were incorrect and the behavior was inconsistent with the behavior of `GeneralParams()`, I believe.

This change should fix the docs and normalize the defaults.