### PR TITLE
Harden the path search for gmxapi CMake config.

### DIFF
--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -314,11 +314,12 @@ def get_search_paths(prefix: pathlib.Path, package: str):
     # but is structured procedurally so that its logic can be most easily compared with
     # the heuristics documented for CMake.
     yield prefix.resolve()
+    package_upper = package.upper()
     for first in [_ for _ in prefix.resolve().iterdir() if _.is_dir()]:
         # < prefix > / (cmake | CMake) /
         if first.name.upper() == 'CMAKE':
             yield first
-        elif first.name.upper().startswith(package.upper()):
+        elif first.name.upper().startswith(package_upper):
             # < prefix > / < name > * /
             yield first
             for second in [_ for _ in first.iterdir() if _.is_dir()]:
@@ -327,7 +328,7 @@ def get_search_paths(prefix: pathlib.Path, package: str):
                     yield second
                     # < prefix > / < name > * / (cmake | CMake) / < name > * /
                     for third in [_ for _ in second.iterdir() if _.is_dir()]:
-                        if third.name.upper().startswith(package.upper()):
+                        if third.name.upper().startswith(package_upper):
                             yield third
                 elif second.name == 'lib':
                     logging.debug(
@@ -340,9 +341,9 @@ def get_search_paths(prefix: pathlib.Path, package: str):
                         if third.name == 'cmake':
                             for fourth in [_ for _ in third.iterdir() if _.is_dir()]:
                                 # < prefix > / < name > * / (lib / < arch >| lib * | share) / cmake / < name > * /
-                                if fourth.name.upper().startswith(package.upper()):
+                                if fourth.name.upper().startswith(package_upper):
                                     yield fourth
-                        elif third.name.upper().startswith(package.upper()):
+                        elif third.name.upper().startswith(package_upper):
                             # < prefix > / < name > * / (lib / < arch >| lib * | share) / < name > * /
                             yield third
                             # < prefix > / < name > * / (lib / < arch >| lib * | share) / < name > * / (cmake | CMake) /
@@ -365,9 +366,9 @@ def get_search_paths(prefix: pathlib.Path, package: str):
                     if second.name == 'cmake':
                         # < prefix > / (lib / < arch >| lib * | share) / cmake / < name > * /
                         for third in [_ for _ in second.iterdir() if _.is_dir()]:
-                            if third.name.upper().startswith(package.upper()):
+                            if third.name.upper().startswith(package_upper):
                                 yield third
-                    elif second.name.upper().startswith(package.upper()):
+                    elif second.name.upper().startswith(package_upper):
                         # < prefix > / (lib / < arch >| lib * | share) / < name > * /
                         yield second
                         # < prefix > / (lib / < arch >| lib * | share) / < name > * / (cmake | CMake) /

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -380,7 +380,7 @@ def get_search_paths(prefix: pathlib.Path, package: str):
                                 yield third
 
 
-def is_valid_package_root(path: typing.Optional[pathlib.Path], package: str, targets: tuple):
+def is_valid_package_root(*, path: typing.Optional[pathlib.Path], package: str, targets: tuple):
     if not path or not path.exists():
         return False
     for subdirectory in get_search_paths(prefix=path, package=package):
@@ -410,8 +410,10 @@ def package_root_from_expanded_config(
         environment variables or *config* entries to check.
 
     """
+    if not isinstance(targets, tuple):
+        raise ValueError('targets must be a tuple')
     for prefix in guess_prefixes(config=config, keys=keys):
-        if is_valid_package_root(prefix, package=package, targets=tuple(*targets)):
+        if is_valid_package_root(path=prefix, package=package, targets=targets):
             return prefix
 
 
@@ -452,7 +454,7 @@ def get_gmxapi_root(*, config: dict, args: typing.Sequence[str]):
     targets = ('gmxapi-config.cmake', 'gmxapiConfig.cmake')
     # Check the environment. Let CMake defines override environment variables.
     cmake_vars = get_cmake_defines(args)
-    if not path or not is_valid_package_root(path, targets=targets, package='gmxapi'):
+    if not path or not is_valid_package_root(path=path, targets=targets, package='gmxapi'):
         path = package_root_from_expanded_config(
             package='gmxapi',
             targets=targets,
@@ -460,7 +462,7 @@ def get_gmxapi_root(*, config: dict, args: typing.Sequence[str]):
             keys=('gmxapi_ROOT', 'GMXAPI_ROOT', 'GMXAPI_DIR', 'GROMACS_DIR', 'CMAKE_PREFIX_PATH'))
 
     # One more try...
-    if not path or not is_valid_package_root(path, targets=targets, package='gmxapi'):
+    if not path or not is_valid_package_root(path=path, targets=targets, package='gmxapi'):
         # Try to guess from args.
         hint = ''
         if '-C' in args:


### PR DESCRIPTION
* Extract a utility function.
* Split on PATH delimiters, if any.
* Clarify.

Fixes #38