### PR TITLE
Remove RDMAV_FORK_SAFE override.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
     env:
       PY: "3.9"
       GROMACS: release-2022
-      GMXAPI: "gmxapi>=0.3"
+      GMXAPI: "gmxapi~=0.3"
     steps:
     - name: Prepare OS
       run: |
@@ -299,7 +299,6 @@ jobs:
         source $HOME/install/gromacs-${GROMACS}/bin/GMXRC
         mkdir -p $HOME/pip-tmp
         TMPDIR=$HOME/pip-tmp \
-        RDMAV_FORK_SAFE=1 \
         # TODO: Remove `--pre` once 0.4 release is final.
         pip install --no-clean --no-build-isolation --no-cache-dir --verbose --pre "${{ env.GMXAPI }}"
         git tag --list
@@ -308,10 +307,7 @@ jobs:
         versioningit .
         rm -rf dist
         python -m build --sdist -x -n
-        # Not sure why libfabric is complaining about `fork()` here, and nowhere else,
-        # but we can work around it with `RDMAV_FORK_SAFE=1` in libfabric < 1.13 and
-        # with `FI_EFA_FORK_SAFE=1` in more recent versions.
-        TMPDIR=$HOME/pip-tmp RDMAV_FORK_SAFE=1 pip install --no-clean --no-build-isolation --no-deps --verbose dist/*
+        TMPDIR=$HOME/pip-tmp pip install --no-clean --no-build-isolation --no-deps --verbose dist/*
         python -m pytest -rA -l --log-cli-level=info --cov=brer --cov-report=xml tests
         # Ref https://github.com/kassonlab/run_brer/issues/81
         # mpiexec -n 2 `which python` -m mpi4py -m pytest -x -rA -l --log-cli-level=info -s --cov=brer --cov-report=xml tests
@@ -381,7 +377,6 @@ jobs:
         source $HOME/install/gromacs-${GROMACS}/bin/GMXRC
         mkdir -p $HOME/pip-tmp
         TMPDIR=$HOME/pip-tmp \
-        RDMAV_FORK_SAFE=1 \
         pip install --no-clean --no-build-isolation --no-cache-dir --verbose --extra-index-url https://test.pypi.org/simple/ --pre "${{ env.GMXAPI }}"
         git tag --list
         pip list
@@ -389,10 +384,7 @@ jobs:
         versioningit .
         rm -rf dist
         python -m build --sdist -x -n
-        # Not sure why libfabric is complaining about `fork()` here, and nowhere else,
-        # but we can work around it with `RDMAV_FORK_SAFE=1` in libfabric < 1.13 and
-        # with `FI_EFA_FORK_SAFE=1` in more recent versions.
-        TMPDIR=$HOME/pip-tmp RDMAV_FORK_SAFE=1 pip install --no-clean --no-build-isolation --no-deps --verbose dist/*
+        TMPDIR=$HOME/pip-tmp pip install --no-clean --no-build-isolation --no-deps --verbose dist/*
         python -m pytest -rA -l --log-cli-level=info --cov=brer --cov-report=xml tests
         # Ref https://github.com/kassonlab/run_brer/issues/81
         # mpiexec -n 2 `which python` -m mpi4py -m pytest -x -rA -l --log-cli-level=info -s --cov=brer --cov-report=xml tests


### PR DESCRIPTION
Remove extra libfabric configuration where it is not necessary.

Follow up to #47. See also https://gitlab.com/gromacs/gromacs/-/issues/4693