### PR TITLE
Tighten pytest compatibilty.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ networkx>=2.0
 numpy>=1
 pip>=22
 pybind11>=2.6
-pytest>=3.9
+pytest>=7.0.0
 setuptools>=61.0.0
 versioningit~=2.0
 wheel

--- a/tests/test_run_data.py
+++ b/tests/test_run_data.py
@@ -88,5 +88,5 @@ def test_run_data(tmpdir, raw_pair_data):
         json.dump(test_data, tmp)
         tmp.flush()
         # Tolerates redundant *name* field. Warns if inconsistent.
-        with pytest.warns(match='instead of'):
+        with pytest.warns(DeprecationWarning, match='instead of'):
             PairDataCollection.create_from(tmp.name)

--- a/tests/test_run_data.py
+++ b/tests/test_run_data.py
@@ -88,5 +88,5 @@ def test_run_data(tmpdir, raw_pair_data):
         json.dump(test_data, tmp)
         tmp.flush()
         # Tolerates redundant *name* field. Warns if inconsistent.
-        with pytest.warns(DeprecationWarning, match='instead of'):
+        with pytest.warns(UserWarning, match='instead of'):
             PairDataCollection.create_from(tmp.name)


### PR DESCRIPTION
* Use backwards compatible syntax for `pytest.warns`.
* Require newer pytest for testing.